### PR TITLE
WIP: Pure-go implementation of Git backend

### DIFF
--- a/vcs/Makefile
+++ b/vcs/Makefile
@@ -3,3 +3,7 @@
 benchmark.txt:
 	go test -test.bench='.*' -test.benchmem > $@ 2>&1
 	cat $@
+
+bench-gogit:
+	# XXX: Remove this before merging, just a bookmark.
+	go test -v -bench=".*GitGoGit" -run XXX

--- a/vcs/bench_test.go
+++ b/vcs/bench_test.go
@@ -62,7 +62,7 @@ func BenchmarkFileSystem_GitGoGit(b *testing.B) {
 
 	cmds, files := makeGitCommandsAndFiles(benchFileSystemCommits)
 	dir := initGitRepository(b, cmds...)
-	r, err := gogit.Open(filepath.Join(dir, ".git"))
+	r, err := gogit.Open(dir)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -266,7 +266,8 @@ func BenchmarkCommits_GitGoGit(b *testing.B) {
 
 	cmds, _ := makeGitCommandsAndFiles(benchCommitsCommits)
 	openRepo := func() benchRepository {
-		r, err := gogit.Open(initGitRepository(b, cmds...))
+		dir := initGitRepository(b, cmds...)
+		r, err := gogit.Open(dir)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/vcs/bench_test.go
+++ b/vcs/bench_test.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/tools/godoc/vfs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/git"
+	gogit "sourcegraph.com/sourcegraph/go-vcs/vcs/git/gogit"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/gitcmd"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/hg"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/hgcmd"
@@ -43,6 +44,25 @@ func BenchmarkFileSystem_GitCmd(b *testing.B) {
 
 	cmds, files := makeGitCommandsAndFiles(benchFileSystemCommits)
 	r, err := gitcmd.Open(initGitRepository(b, cmds...))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchFileSystem(b, r, "mytag", files)
+	}
+}
+
+func BenchmarkFileSystem_GitGoGit(b *testing.B) {
+	defer func() {
+		b.StopTimer()
+		b.StartTimer()
+	}()
+
+	cmds, files := makeGitCommandsAndFiles(benchFileSystemCommits)
+	dir := initGitRepository(b, cmds...)
+	r, err := gogit.Open(filepath.Join(dir, ".git"))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/vcs/bench_test.go
+++ b/vcs/bench_test.go
@@ -149,6 +149,28 @@ func BenchmarkGetCommit_GitCmd(b *testing.B) {
 	}
 }
 
+func BenchmarkGetCommit_GitGoGit(b *testing.B) {
+	defer func() {
+		b.StopTimer()
+		b.StartTimer()
+	}()
+
+	cmds, _ := makeGitCommandsAndFiles(benchGetCommitCommits)
+	r := makeGitRepositoryGoGit(b, cmds...)
+	openRepo := func() benchRepository {
+		r, err := gogit.Open(r.RepoDir())
+		if err != nil {
+			b.Fatal(err)
+		}
+		return r
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchGetCommit(b, openRepo, "mytag")
+	}
+}
+
 func BenchmarkGetCommit_HgNative(b *testing.B) {
 	defer func() {
 		b.StopTimer()
@@ -224,6 +246,27 @@ func BenchmarkCommits_GitCmd(b *testing.B) {
 	cmds, _ := makeGitCommandsAndFiles(benchCommitsCommits)
 	openRepo := func() benchRepository {
 		r, err := gitcmd.Open(initGitRepository(b, cmds...))
+		if err != nil {
+			b.Fatal(err)
+		}
+		return r
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchCommits(b, openRepo, "mytag")
+	}
+}
+
+func BenchmarkCommits_GitGoGit(b *testing.B) {
+	defer func() {
+		b.StopTimer()
+		b.StartTimer()
+	}()
+
+	cmds, _ := makeGitCommandsAndFiles(benchCommitsCommits)
+	openRepo := func() benchRepository {
+		r, err := gogit.Open(initGitRepository(b, cmds...))
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/vcs/git/gogit/errors.go
+++ b/vcs/git/gogit/errors.go
@@ -1,0 +1,15 @@
+package git
+
+import (
+	"github.com/shazow/go-git"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+)
+
+func standardizeError(err error) error {
+	switch err := err.(type) {
+	case git.ObjectNotFound:
+		return vcs.ErrCommitNotFound
+	default:
+		return err
+	}
+}

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -50,7 +50,13 @@ func Open(dir string) (*Repository, error) {
 // specifier resolves to, or a non-nil error if there is no such
 // revision.
 func (r *Repository) ResolveRevision(spec string) (vcs.CommitID, error) {
-	return vcs.CommitID(""), errors.New("gogit: ResolveRevision not implemented")
+	// TODO: git rev-parse supports a horde of complex syntaxes, it will be a fair bit more work to support all of them.
+	// e.g. "master@{yesterday}", "master~3", and various text/path/tree traversal search.
+	ci, err := r.ResolveTag(spec)
+	if err == nil {
+		return ci, nil
+	}
+	return r.ResolveBranch(spec)
 }
 
 // ResolveTag returns the tag with the given name, or

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -1,12 +1,40 @@
 package git
 
 import (
+	"fmt"
+
+	"github.com/gogits/git"
 	"golang.org/x/tools/godoc/vfs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
 )
 
+func init() {
+	// Overwrite the git opener to return repositories that use the
+	// gogits native-go implementation.
+	vcs.RegisterOpener("git", func(dir string) (vcs.Repository, error) {
+		return Open(dir)
+	})
+}
+
 // Repository is a git VCS repository.
 type Repository struct {
+	repo *git.Repository
+}
+
+func (r *Repository) String() string {
+	return fmt.Sprintf("git (gogit) repo at %s", r.repo.Path)
+}
+
+func Open(dir string) (*Repository, error) {
+	repo, err := git.OpenRepository(dir)
+	if err != nil {
+		// FIXME: Wrap in vcs error?
+		return nil, err
+	}
+
+	return &Repository{
+		repo: repo,
+	}, nil
 }
 
 // ResolveRevision returns the revision that the given revision

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -3,6 +3,7 @@ package git
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/shazow/go-git"
@@ -35,7 +36,7 @@ func (r *Repository) String() string {
 }
 
 func Open(dir string) (*Repository, error) {
-	repo, err := git.OpenRepository(dir)
+	repo, err := git.OpenRepository(filepath.Join(dir, ".git"))
 	if err != nil {
 		// FIXME: Wrap in vcs error?
 		return nil, err
@@ -63,8 +64,11 @@ func (r *Repository) ResolveRevision(spec string) (vcs.CommitID, error) {
 // ErrTagNotFound if no such tag exists.
 func (r *Repository) ResolveTag(name string) (vcs.CommitID, error) {
 	id, err := r.repo.GetCommitIdOfTag(name)
-	if err != nil {
+	if git.IsNotFound(err) {
 		return "", vcs.ErrTagNotFound
+	} else if err != nil {
+		// Unexpected error
+		return "", err
 	}
 	return vcs.CommitID(id), nil
 }
@@ -73,8 +77,11 @@ func (r *Repository) ResolveTag(name string) (vcs.CommitID, error) {
 // ErrBranchNotFound if no such branch exists.
 func (r *Repository) ResolveBranch(name string) (vcs.CommitID, error) {
 	id, err := r.repo.GetCommitIdOfBranch(name)
-	if err != nil {
+	if git.IsNotFound(err) {
 		return "", vcs.ErrBranchNotFound
+	} else if err != nil {
+		// Unexpected error
+		return "", err
 	}
 	return vcs.CommitID(id), nil
 }

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -102,9 +102,8 @@ func (r *Repository) Branches(opt vcs.BranchesOptions) ([]*vcs.Branch, error) {
 	if err != nil {
 		return nil, err
 	}
-	defaultOpt := vcs.BranchesOptions{}
-	if opt != defaultOpt {
-		return nil, fmt.Errorf("vcs.BranchesOptions options not implemented")
+	if opt.BehindAheadBranch != "" {
+		return nil, fmt.Errorf("vcs.BranchesOptions BehindAheadBranch not implemented")
 	}
 
 	var branches []*vcs.Branch
@@ -114,8 +113,17 @@ func (r *Repository) Branches(opt vcs.BranchesOptions) ([]*vcs.Branch, error) {
 			return nil, err
 		}
 		branch := &vcs.Branch{Name: name, Head: id}
+		if opt.IncludeCommit {
+			branch.Commit, err = r.GetCommit(id)
+			if err != nil {
+				return nil, err
+			}
+		}
 		branches = append(branches, branch)
 	}
+
+	// TODO: opt.MergedInto
+	// TODO: opt.ContainsCommit
 	return branches, nil
 }
 
@@ -134,6 +142,7 @@ func (r *Repository) Tags() ([]*vcs.Tag, error) {
 		}
 		tags = append(tags, &vcs.Tag{Name: name, CommitID: vcs.CommitID(id)})
 	}
+
 	return tags, nil
 }
 

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -63,7 +63,11 @@ func (r *Repository) ResolveRevision(spec string) (vcs.CommitID, error) {
 	if err == nil {
 		return ci, nil
 	}
-	return r.ResolveBranch(spec)
+	ci, err = r.ResolveBranch(spec)
+	if err == nil {
+		return ci, nil
+	}
+	return ci, vcs.ErrRevisionNotFound
 }
 
 // ResolveTag returns the tag with the given name, or

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -1,0 +1,70 @@
+package git
+
+import (
+	"golang.org/x/tools/godoc/vfs"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+)
+
+// Repository is a git VCS repository.
+type Repository struct {
+}
+
+// ResolveRevision returns the revision that the given revision
+// specifier resolves to, or a non-nil error if there is no such
+// revision.
+func (r *Repository) ResolveRevision(spec string) (vcs.CommitID, error) {
+	panic("gogit: not implemented")
+}
+
+// ResolveTag returns the tag with the given name, or
+// ErrTagNotFound if no such tag exists.
+func (r *Repository) ResolveTag(name string) (vcs.CommitID, error) {
+	panic("gogit: not implemented")
+}
+
+// ResolveBranch returns the branch with the given name, or
+// ErrBranchNotFound if no such branch exists.
+func (r *Repository) ResolveBranch(name string) (vcs.CommitID, error) {
+	panic("gogit: not implemented")
+}
+
+// Branches returns a list of all branches in the repository.
+func (r *Repository) Branches(branchesOpts vcs.BranchesOptions) ([]*vcs.Branch, error) {
+	panic("gogit: not implemented")
+}
+
+// Tags returns a list of all tags in the repository.
+func (r *Repository) Tags() ([]*vcs.Tag, error) {
+	panic("gogit: not implemented")
+}
+
+// GetCommit returns the commit with the given commit ID, or
+// ErrCommitNotFound if no such commit exists.
+func (r *Repository) GetCommit(commitID vcs.CommitID) (*vcs.Commit, error) {
+	panic("gogit: not implemented")
+}
+
+// Commits returns all commits matching the options, as well as
+// the total number of commits (the count of which is not subject
+// to the N/Skip options).
+//
+// Optionally, the caller can request the total not to be computed,
+// as this can be expensive for large branches.
+func (r *Repository) Commits(commitOpts vcs.CommitsOptions) (commits []*vcs.Commit, total uint, err error) {
+	panic("gogit: not implemented")
+}
+
+// Committers returns the per-author commit statistics of the repo.
+func (r *Repository) Committers(committerOpts vcs.CommittersOptions) ([]*vcs.Committer, error) {
+	panic("gogit: not implemented")
+}
+
+// FileSystem opens the repository file tree at a given commit ID.
+func (r *Repository) FileSystem(at vcs.CommitID) (vfs.FileSystem, error) {
+	// Implementations may choose to check that the commit exists
+	// before FileSystem returns or to defer the check until
+	// operations are performed on the filesystem. (For example, an
+	// implementation proxying a remote filesystem may not want to
+	// incur the round-trip to check that the commit exists.)
+	panic("gogit: not implemented")
+}

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -169,10 +169,14 @@ func (r *Repository) Committers(committerOpts vcs.CommittersOptions) ([]*vcs.Com
 
 // FileSystem opens the repository file tree at a given commit ID.
 func (r *Repository) FileSystem(at vcs.CommitID) (vfs.FileSystem, error) {
-	// Implementations may choose to check that the commit exists
-	// before FileSystem returns or to defer the check until
-	// operations are performed on the filesystem. (For example, an
-	// implementation proxying a remote filesystem may not want to
-	// incur the round-trip to check that the commit exists.)
-	panic("gogit: not implemented")
+	tree, err := r.repo.GetTree(string(at))
+	if err != nil {
+		return nil, err
+	}
+	return &filesystem{
+		dir:  r.repo.Path,
+		oid:  string(at),
+		tree: tree,
+		repo: r.repo,
+	}, nil
 }

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -3,6 +3,7 @@ package git
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -36,7 +37,12 @@ func (r *Repository) String() string {
 }
 
 func Open(dir string) (*Repository, error) {
-	repo, err := git.OpenRepository(filepath.Join(dir, ".git"))
+	if _, err := os.Stat(filepath.Join(dir, ".git")); !os.IsNotExist(err) {
+		// Append .git to path
+		dir = filepath.Join(dir, ".git")
+	}
+
+	repo, err := git.OpenRepository(dir)
 	if err != nil {
 		// FIXME: Wrap in vcs error?
 		return nil, err

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -165,26 +165,26 @@ func (r *Repository) GetCommit(commitID vcs.CommitID) (*vcs.Commit, error) {
 //
 // Optionally, the caller can request the total not to be computed,
 // as this can be expensive for large branches.
-func (r *Repository) Commits(opts vcs.CommitsOptions) ([]*vcs.Commit, uint, error) {
+func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error) {
 	var total uint = 0
 	var commits []*vcs.Commit
 	var err error
 
-	cur, err := r.repo.GetCommit(string(opts.Head))
+	cur, err := r.repo.GetCommit(string(opt.Head))
 	if err != nil {
 		return commits, total, standardizeError(err)
 	}
 
 	parents := []*git.Commit{cur}
-	for opts.N == 0 || opts.N > uint(len(commits)) {
+	for opt.N == 0 || opt.N > uint(len(commits)) {
 		// Pop FIFO
 		cur, parents = parents[len(parents)-1], parents[:len(parents)-1]
-		if cur.Id.String() == string(opts.Base) {
-			// FIXME: Is this the correct condition for opts.Base? Please review.
+		if cur.Id.String() == string(opt.Base) {
+			// FIXME: Is this the correct condition for opt.Base? Please review.
 			break
 		}
 
-		if opts.Skip <= total {
+		if opt.Skip <= total {
 			ci, err := r.GetCommit(vcs.CommitID(cur.Id.String()))
 			if err != nil {
 				return nil, 0, err
@@ -206,7 +206,7 @@ func (r *Repository) Commits(opts vcs.CommitsOptions) ([]*vcs.Commit, uint, erro
 		}
 	}
 
-	if opts.NoTotal {
+	if opt.NoTotal {
 		return commits, 0, err
 	}
 

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -169,14 +169,14 @@ func (r *Repository) Committers(committerOpts vcs.CommittersOptions) ([]*vcs.Com
 
 // FileSystem opens the repository file tree at a given commit ID.
 func (r *Repository) FileSystem(at vcs.CommitID) (vfs.FileSystem, error) {
-	tree, err := r.repo.GetTree(string(at))
+	ci, err := r.repo.GetCommit(string(at))
 	if err != nil {
 		return nil, err
 	}
 	return &filesystem{
 		dir:  r.repo.Path,
 		oid:  string(at),
-		tree: tree,
+		tree: &ci.Tree,
 		repo: r.repo,
 	}, nil
 }

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -45,7 +46,7 @@ func Open(dir string) (*Repository, error) {
 // specifier resolves to, or a non-nil error if there is no such
 // revision.
 func (r *Repository) ResolveRevision(spec string) (vcs.CommitID, error) {
-	panic("gogit: not implemented")
+	return vcs.CommitID(""), errors.New("gogit: ResolveRevision not implemented")
 }
 
 // ResolveTag returns the tag with the given name, or
@@ -159,12 +160,12 @@ func (r *Repository) GetCommit(commitID vcs.CommitID) (*vcs.Commit, error) {
 // Optionally, the caller can request the total not to be computed,
 // as this can be expensive for large branches.
 func (r *Repository) Commits(commitOpts vcs.CommitsOptions) (commits []*vcs.Commit, total uint, err error) {
-	panic("gogit: not implemented")
+	return nil, 0, errors.New("gogit: Commits not implemented")
 }
 
 // Committers returns the per-author commit statistics of the repo.
 func (r *Repository) Committers(committerOpts vcs.CommittersOptions) ([]*vcs.Committer, error) {
-	panic("gogit: not implemented")
+	return nil, errors.New("gogit: Committers not implemented")
 }
 
 // FileSystem opens the repository file tree at a given commit ID.

--- a/vcs/git/gogit/repo.go
+++ b/vcs/git/gogit/repo.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gogits/git"
+	"github.com/shazow/go-git"
 	"golang.org/x/tools/godoc/vfs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
 	"sourcegraph.com/sqs/pbtypes"

--- a/vcs/git/gogit/vfs.go
+++ b/vcs/git/gogit/vfs.go
@@ -118,6 +118,7 @@ func (fs *filesystem) Stat(path string) (os.FileInfo, error) {
 
 		// Use original filename.
 		fi.(*util.FileInfo).Name_ = filepath.Base(path)
+		return fi, nil
 	}
 
 	fi, err := fs.makeFileInfo(path, e)

--- a/vcs/git/gogit/vfs.go
+++ b/vcs/git/gogit/vfs.go
@@ -207,7 +207,11 @@ func (fs *filesystem) ReadDir(path string) ([]os.FileInfo, error) {
 		}
 	}
 
-	entries := subtree.ListEntries()
+	entries, err := subtree.ListEntries()
+	if err != nil {
+		return nil, err
+	}
+
 	fis := make([]os.FileInfo, 0, len(entries))
 	for _, e := range entries {
 		fi, err := fs.makeFileInfo(filepath.Join(path, e.Name()), e)

--- a/vcs/git/gogit/vfs.go
+++ b/vcs/git/gogit/vfs.go
@@ -1,0 +1,225 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/tools/godoc/vfs"
+
+	"github.com/gogits/git"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs/internal"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs/util"
+)
+
+type filesystem struct {
+	dir  string
+	oid  string
+	tree *git.Tree
+
+	repo *git.Repository
+}
+
+func (fs *filesystem) readFileBytes(name string) ([]byte, error) {
+	e, err := fs.tree.GetTreeEntryByPath(name)
+	if err != nil {
+		return nil, err
+	}
+
+	switch e.Type {
+	case git.ObjectBlob:
+		reader, err := e.Blob().Data()
+		if err != nil {
+			return nil, err
+		}
+		b, err := ioutil.ReadAll(reader)
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	case git.ObjectCommit:
+		// Return empty for a submodule for now.
+		return nil, nil
+	}
+	return nil, fmt.Errorf("read unexpected entry type %q (expected blob or submodule(commit))", e.Type)
+}
+
+func (fs *filesystem) Open(name string) (vfs.ReadSeekCloser, error) {
+	name = internal.Rel(name)
+
+	b, err := fs.readFileBytes(name)
+	if err != nil {
+		return nil, err
+	}
+	return util.NopCloser{ReadSeeker: bytes.NewReader(b)}, nil
+}
+
+func (fs *filesystem) Lstat(path string) (os.FileInfo, error) {
+	path = filepath.Clean(internal.Rel(path))
+
+	mtime, err := fs.getModTime()
+	if err != nil {
+		return nil, err
+	}
+
+	if path == "." {
+		return &util.FileInfo{Mode_: os.ModeDir, ModTime_: mtime}, nil
+	}
+
+	e, err := fs.tree.GetTreeEntryByPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	fi, err := fs.makeFileInfo(path, e)
+	if err != nil {
+		return nil, err
+	}
+	fi.ModTime_ = mtime
+
+	return fi, nil
+}
+
+func (fs *filesystem) Stat(path string) (os.FileInfo, error) {
+	path = filepath.Clean(internal.Rel(path))
+
+	mtime, err := fs.getModTime()
+	if err != nil {
+		return nil, err
+	}
+
+	if path == "." {
+		return &util.FileInfo{Mode_: os.ModeDir, ModTime_: mtime}, nil
+	}
+
+	e, err := fs.tree.GetTreeEntryByPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if e.EntryMode() == git.ModeSymlink {
+		// Dereference symlink.
+		reader, err := e.Blob().Data()
+		if err != nil {
+			return nil, err
+		}
+		b, err := ioutil.ReadAll(reader)
+		if err != nil {
+			return nil, err
+		}
+		fi, err := fs.Lstat(string(b))
+		if err != nil {
+			return nil, err
+		}
+
+		// Use original filename.
+		fi.(*util.FileInfo).Name_ = filepath.Base(path)
+	}
+
+	fi, err := fs.makeFileInfo(path, e)
+	if err != nil {
+		return nil, err
+	}
+	fi.ModTime_ = mtime
+
+	return fi, nil
+}
+
+func (fs *filesystem) getModTime() (time.Time, error) {
+	commit, err := fs.repo.GetCommit(fs.oid)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return commit.Author.When, nil
+}
+
+func (fs *filesystem) makeFileInfo(path string, e *git.TreeEntry) (*util.FileInfo, error) {
+	switch e.Type {
+	case git.ObjectBlob:
+		return fs.fileInfo(e)
+	case git.ObjectTree:
+		return fs.dirInfo(e), nil
+	case git.ObjectCommit:
+		// FIXME: No submodule support. :'(
+		panic("submodules not implemented")
+	}
+
+	return nil, fmt.Errorf("unexpected object type %v while making file info (expected blob, tree, or commit)", e.Type)
+}
+
+func (fs *filesystem) fileInfo(e *git.TreeEntry) (*util.FileInfo, error) {
+	var sys interface{}
+	var mode os.FileMode
+	if e.EntryMode() == git.ModeExec {
+		mode |= 0111
+	}
+	if e.EntryMode() == git.ModeSymlink {
+		mode |= os.ModeSymlink
+
+		// Dereference symlink.
+		reader, err := e.Blob().Data()
+		if err != nil {
+			return nil, err
+		}
+		b, err := ioutil.ReadAll(reader)
+		if err != nil {
+			return nil, err
+		}
+
+		sys = vcs.SymlinkInfo{Dest: string(b)}
+	}
+
+	return &util.FileInfo{
+		Name_: e.Name(),
+		Size_: e.Size(),
+		Mode_: mode,
+		Sys_:  sys,
+	}, nil
+}
+
+func (fs *filesystem) dirInfo(e *git.TreeEntry) *util.FileInfo {
+	return &util.FileInfo{
+		Name_: e.Name(),
+		Mode_: os.ModeDir,
+	}
+}
+
+func (fs *filesystem) ReadDir(path string) ([]os.FileInfo, error) {
+	path = filepath.Clean(internal.Rel(path))
+
+	var subtree *git.Tree
+	if path == "." {
+		subtree = fs.tree
+	} else {
+		e, err := fs.tree.GetTreeEntryByPath(path)
+		if err != nil {
+			return nil, err
+		}
+
+		// FIXME: This looks redundant?
+		subtree, err = fs.repo.GetTree(e.Id.String())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	entries := subtree.ListEntries()
+	fis := make([]os.FileInfo, 0, len(entries))
+	for _, e := range entries {
+		fi, err := fs.makeFileInfo(filepath.Join(path, e.Name()), e)
+		if err != nil {
+			return nil, err
+		}
+		fis = append(fis, fi)
+	}
+
+	return fis, nil
+}
+
+func (fs *filesystem) String() string {
+	return fmt.Sprintf("git repository %s commit %s (gogit)", fs.dir, fs.oid)
+}

--- a/vcs/git/gogit/vfs.go
+++ b/vcs/git/gogit/vfs.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/tools/godoc/vfs"
 
-	"github.com/gogits/git"
+	"github.com/shazow/go-git"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/internal"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/util"

--- a/vcs/git/gogit/vfs.go
+++ b/vcs/git/gogit/vfs.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -146,7 +147,7 @@ func (fs *filesystem) makeFileInfo(path string, e *git.TreeEntry) (*util.FileInf
 		return fs.dirInfo(e), nil
 	case git.ObjectCommit:
 		// FIXME: No submodule support. :'(
-		panic("submodules not implemented")
+		return nil, errors.New("go-git: submodules not implemented.")
 	}
 
 	return nil, fmt.Errorf("unexpected object type %v while making file info (expected blob, tree, or commit)", e.Type)

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -234,6 +234,11 @@ func TestRepository_ResolveRevision_error(t *testing.T) {
 			spec:    "doesntexist",
 			wantErr: vcs.ErrRevisionNotFound,
 		},
+		"git gogit testcase1": {
+			repo:    makeGitRepositoryGoGit(t, gitCommands...),
+			spec:    "doesntexist",
+			wantErr: vcs.ErrRevisionNotFound,
+		},
 		"hg testcase1": {
 			repo:    makeHgRepositoryNative(t, hgCommands...),
 			spec:    "doesntexist",
@@ -254,6 +259,11 @@ func TestRepository_ResolveRevision_error(t *testing.T) {
 		},
 		"git cmd testcase2": {
 			repo:    makeGitRepositoryCmd(t, gitCommands...),
+			spec:    "2874b2ef9be165966e5620fc29b592c041262721",
+			wantErr: vcs.ErrRevisionNotFound,
+		},
+		"git gogit testcase2": {
+			repo:    makeGitRepositoryGoGit(t, gitCommands...),
 			spec:    "2874b2ef9be165966e5620fc29b592c041262721",
 			wantErr: vcs.ErrRevisionNotFound,
 		},

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -60,7 +60,7 @@ func TestRepository_ResolveBranch(t *testing.T) {
 			branch:       "master",
 			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:         makeGitRepositoryGoGit(t, gitCommands...),
 			branch:       "master",
 			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
@@ -118,7 +118,7 @@ func TestRepository_ResolveBranch_error(t *testing.T) {
 			branch:  "doesntexist",
 			wantErr: vcs.ErrBranchNotFound,
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:    makeGitRepositoryGoGit(t, gitCommands...),
 			branch:  "doesntexist",
 			wantErr: vcs.ErrBranchNotFound,
@@ -176,7 +176,7 @@ func TestRepository_ResolveRevision(t *testing.T) {
 			spec:         "master",
 			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:         makeGitRepositoryGoGit(t, gitCommands...),
 			spec:         "master",
 			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
@@ -312,7 +312,7 @@ func TestRepository_ResolveTag(t *testing.T) {
 			tag:          "t",
 			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:         makeGitRepositoryGoGit(t, gitCommands...),
 			tag:          "t",
 			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
@@ -370,7 +370,7 @@ func TestRepository_ResolveTag_error(t *testing.T) {
 			tag:     "doesntexist",
 			wantErr: vcs.ErrTagNotFound,
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:    makeGitRepositoryGoGit(t, gitCommands...),
 			tag:     "doesntexist",
 			wantErr: vcs.ErrTagNotFound,
@@ -432,7 +432,7 @@ func TestRepository_Branches(t *testing.T) {
 			repo:         makeGitRepositoryCmd(t, gitCommands...),
 			wantBranches: []*vcs.Branch{{Name: "b0", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "b1", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "master", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}},
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:         makeGitRepositoryGoGit(t, gitCommands...),
 			wantBranches: []*vcs.Branch{{Name: "b0", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "b1", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "master", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}},
 		},
@@ -673,7 +673,7 @@ func TestRepository_Tags(t *testing.T) {
 			repo:     makeGitRepositoryCmd(t, gitCommands...),
 			wantTags: []*vcs.Tag{{Name: "t0", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "t1", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}},
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:     makeGitRepositoryGoGit(t, gitCommands...),
 			wantTags: []*vcs.Tag{{Name: "t0", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "t1", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}},
 		},
@@ -745,7 +745,7 @@ func TestRepository_GetCommit(t *testing.T) {
 			id:         "b266c7e3ca00b1a17ad0b1449825d0854225c007",
 			wantCommit: wantGitCommit,
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:       makeGitRepositoryGoGit(t, gitCommands...),
 			id:         "b266c7e3ca00b1a17ad0b1449825d0854225c007",
 			wantCommit: wantGitCommit,
@@ -847,7 +847,7 @@ func TestRepository_Commits(t *testing.T) {
 			wantCommits: wantGitCommits,
 			wantTotal:   2,
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:        makeGitRepositoryGoGit(t, gitCommands...),
 			id:          "b266c7e3ca00b1a17ad0b1449825d0854225c007",
 			wantCommits: wantGitCommits,
@@ -967,7 +967,7 @@ func TestRepository_Commits_options(t *testing.T) {
 			wantCommits: wantGitCommits,
 			wantTotal:   3,
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:        makeGitRepositoryGoGit(t, gitCommands...),
 			opt:         vcs.CommitsOptions{Head: "ade564eba4cf904492fb56dcd287ac633e6e082c", N: 1, Skip: 1},
 			wantCommits: wantGitCommits,
@@ -1168,7 +1168,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 			testFileInfoSys: true,
 			git:             true,
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:     makeGitRepositoryGoGit(t, gitCommands...),
 			commitID: "85d3a39020cf28af4b887552fcab9e31a49f2ced",
 
@@ -1322,7 +1322,7 @@ func TestRepository_FileSystem(t *testing.T) {
 			first:  "b6602ca96bdc0ab647278577a3c6edcb8fe18fb0",
 			second: "ace35f1597e087fe2d302ed6cb2763174e6b9660",
 		},
-		"git gogits": {
+		"git go-git": {
 			repo:   makeGitRepositoryGoGit(t, gitCommands...),
 			first:  "b6602ca96bdc0ab647278577a3c6edcb8fe18fb0",
 			second: "ace35f1597e087fe2d302ed6cb2763174e6b9660",
@@ -1570,7 +1570,7 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 		"git cmd": {
 			repo: makeGitRepositoryCmd(t, gitCommands...),
 		},
-		"git gogits": {
+		"git go-git": {
 			repo: makeGitRepositoryGoGit(t, gitCommands...),
 		},
 	}

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -594,6 +594,13 @@ func TestRepository_Branches_BehindAheadCounts(t *testing.T) {
 		"git checkout old_work",
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo9 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 	}
+	gitBranches := []*vcs.Branch{
+		{Counts: &vcs.BehindAhead{Behind: 5, Ahead: 1}, Name: "old_work", Head: "26692c614c59ddaef4b57926810aac7d5f0e94f0"},
+		{Counts: &vcs.BehindAhead{Behind: 0, Ahead: 3}, Name: "dev", Head: "6724953367f0cd9a7755bac46ee57f4ab0c1aad8"},
+		{Counts: &vcs.BehindAhead{Behind: 0, Ahead: 0}, Name: "master", Head: "8ea26e077a8fb9aa502c3fe2cfa3ce4e052d1a76"},
+	}
+	sort.Sort(vcs.Branches(gitBranches))
+
 	tests := map[string]struct {
 		repo interface {
 			Branches(vcs.BranchesOptions) ([]*vcs.Branch, error)
@@ -601,12 +608,12 @@ func TestRepository_Branches_BehindAheadCounts(t *testing.T) {
 		wantBranches []*vcs.Branch
 	}{
 		"git cmd": {
-			repo: makeGitRepositoryCmd(t, gitCommands...),
-			wantBranches: []*vcs.Branch{
-				{Counts: &vcs.BehindAhead{Behind: 5, Ahead: 1}, Name: "old_work", Head: "26692c614c59ddaef4b57926810aac7d5f0e94f0"},
-				{Counts: &vcs.BehindAhead{Behind: 0, Ahead: 3}, Name: "dev", Head: "6724953367f0cd9a7755bac46ee57f4ab0c1aad8"},
-				{Counts: &vcs.BehindAhead{Behind: 0, Ahead: 0}, Name: "master", Head: "8ea26e077a8fb9aa502c3fe2cfa3ce4e052d1a76"},
-			},
+			repo:         makeGitRepositoryCmd(t, gitCommands...),
+			wantBranches: gitBranches,
+		},
+		"git gogit": {
+			repo:         makeGitRepositoryGoGit(t, gitCommands...),
+			wantBranches: gitBranches,
 		},
 	}
 
@@ -616,6 +623,7 @@ func TestRepository_Branches_BehindAheadCounts(t *testing.T) {
 			t.Errorf("%s: Branches: %s", label, err)
 			continue
 		}
+		sort.Sort(vcs.Branches(branches))
 
 		if !reflect.DeepEqual(branches, test.wantBranches) {
 			t.Errorf("%s: got branches == %v, want %v", label, asJSON(branches), asJSON(test.wantBranches))

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -1131,6 +1131,12 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 			testFileInfoSys: true,
 			git:             true,
 		},
+		"git gogits": {
+			repo:     makeGitRepositoryGoGit(t, gitCommands...),
+			commitID: "85d3a39020cf28af4b887552fcab9e31a49f2ced",
+
+			testFileInfoSys: true,
+		},
 		"hg native": {
 			repo:     makeHgRepositoryNative(t, hgCommands...),
 			commitID: hgCommitID,
@@ -1276,6 +1282,11 @@ func TestRepository_FileSystem(t *testing.T) {
 		},
 		"git cmd": {
 			repo:   makeGitRepositoryCmd(t, gitCommands...),
+			first:  "b6602ca96bdc0ab647278577a3c6edcb8fe18fb0",
+			second: "ace35f1597e087fe2d302ed6cb2763174e6b9660",
+		},
+		"git gogits": {
+			repo:   makeGitRepositoryGoGit(t, gitCommands...),
 			first:  "b6602ca96bdc0ab647278577a3c6edcb8fe18fb0",
 			second: "ace35f1597e087fe2d302ed6cb2763174e6b9660",
 		},
@@ -1521,6 +1532,9 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 		},
 		"git cmd": {
 			repo: makeGitRepositoryCmd(t, gitCommands...),
+		},
+		"git gogits": {
+			repo: makeGitRepositoryGoGit(t, gitCommands...),
 		},
 	}
 

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -523,6 +523,13 @@ func TestRepository_Branches_ContainsCommit(t *testing.T) {
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m branch2 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 	}
 
+	// Pre-sorted branches
+	gitWantBranches := map[string][]*vcs.Branch{
+		"920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9": {{Name: "branch2", Head: "920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9"}},
+		"1224d334dfe08f4693968ea618ad63ae86ec16ca": {{Name: "master", Head: "1224d334dfe08f4693968ea618ad63ae86ec16ca"}},
+		"2816a72df28f699722156e545d038a5203b959de": {{Name: "branch2", Head: "920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9"}, {Name: "master", Head: "1224d334dfe08f4693968ea618ad63ae86ec16ca"}},
+	}
+
 	tests := map[string]struct {
 		repo interface {
 			Branches(vcs.BranchesOptions) ([]*vcs.Branch, error)
@@ -530,20 +537,12 @@ func TestRepository_Branches_ContainsCommit(t *testing.T) {
 		commitToWantBranches map[string][]*vcs.Branch
 	}{
 		"git cmd": {
-			repo: makeGitRepositoryCmd(t, gitCommands...),
-			commitToWantBranches: map[string][]*vcs.Branch{
-				"920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9": {{Name: "branch2", Head: "920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9"}},
-				"1224d334dfe08f4693968ea618ad63ae86ec16ca": {{Name: "master", Head: "1224d334dfe08f4693968ea618ad63ae86ec16ca"}},
-				"2816a72df28f699722156e545d038a5203b959de": {{Name: "master", Head: "1224d334dfe08f4693968ea618ad63ae86ec16ca"}, {Name: "branch2", Head: "920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9"}},
-			},
+			repo:                 makeGitRepositoryCmd(t, gitCommands...),
+			commitToWantBranches: gitWantBranches,
 		},
 		"git gogit": {
-			repo: makeGitRepositoryGoGit(t, gitCommands...),
-			commitToWantBranches: map[string][]*vcs.Branch{
-				"920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9": {{Name: "branch2", Head: "920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9"}},
-				"1224d334dfe08f4693968ea618ad63ae86ec16ca": {{Name: "master", Head: "1224d334dfe08f4693968ea618ad63ae86ec16ca"}},
-				"2816a72df28f699722156e545d038a5203b959de": {{Name: "master", Head: "1224d334dfe08f4693968ea618ad63ae86ec16ca"}, {Name: "branch2", Head: "920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9"}},
-			},
+			repo:                 makeGitRepositoryGoGit(t, gitCommands...),
+			commitToWantBranches: gitWantBranches,
 		},
 	}
 
@@ -555,8 +554,9 @@ func TestRepository_Branches_ContainsCommit(t *testing.T) {
 				continue
 			}
 
+			sort.Sort(vcs.Branches(branches))
 			if !reflect.DeepEqual(branches, wantBranches) {
-				t.Errorf("%s: got branches == %v, want %v", label, asJSON(branches), asJSON(wantBranches))
+				t.Errorf("%s: ContainsCommit %q: got branches == %v, want %v", label, commit, asJSON(branches), asJSON(wantBranches))
 			}
 		}
 	}

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -720,6 +720,11 @@ func TestRepository_GetCommit(t *testing.T) {
 			id:         "b266c7e3ca00b1a17ad0b1449825d0854225c007",
 			wantCommit: wantGitCommit,
 		},
+		"git gogits": {
+			repo:       makeGitRepositoryGoGit(t, gitCommands...),
+			id:         "b266c7e3ca00b1a17ad0b1449825d0854225c007",
+			wantCommit: wantGitCommit,
+		},
 		"hg": {
 			repo:       makeHgRepositoryNative(t, hgCommands...),
 			id:         "c6320cdba5ebc6933bd7c94751dcd633d6aa0759",

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -991,6 +991,15 @@ func TestRepository_Commits_options(t *testing.T) {
 			wantCommits: wantGitCommits2,
 			wantTotal:   1,
 		},
+		"git go-git Head": {
+			repo: makeGitRepositoryGoGit(t, gitCommands...),
+			opt: vcs.CommitsOptions{
+				Head: "ade564eba4cf904492fb56dcd287ac633e6e082c",
+				Base: "b266c7e3ca00b1a17ad0b1449825d0854225c007",
+			},
+			wantCommits: wantGitCommits2,
+			wantTotal:   1,
+		},
 		"hg native": {
 			repo:        makeHgRepositoryNative(t, hgCommands...),
 			opt:         vcs.CommitsOptions{Head: "443def46748a0c02c312bb4fdc6231d6ede45f49", N: 1, Skip: 1},

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -60,6 +60,11 @@ func TestRepository_ResolveBranch(t *testing.T) {
 			branch:       "master",
 			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
 		},
+		"git gogits": {
+			repo:         makeGitRepositoryGoGit(t, gitCommands...),
+			branch:       "master",
+			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
+		},
 		"hg native": {
 			repo:         makeHgRepositoryNative(t, hgCommands...),
 			branch:       "default",
@@ -113,6 +118,11 @@ func TestRepository_ResolveBranch_error(t *testing.T) {
 			branch:  "doesntexist",
 			wantErr: vcs.ErrBranchNotFound,
 		},
+		"git gogits": {
+			repo:    makeGitRepositoryGoGit(t, gitCommands...),
+			branch:  "doesntexist",
+			wantErr: vcs.ErrBranchNotFound,
+		},
 		"hg": {
 			repo:    makeHgRepositoryNative(t, hgCommands...),
 			branch:  "doesntexist",
@@ -163,6 +173,11 @@ func TestRepository_ResolveRevision(t *testing.T) {
 		},
 		"git cmd": {
 			repo:         makeGitRepositoryCmd(t, gitCommands...),
+			spec:         "master",
+			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
+		},
+		"git gogits": {
+			repo:         makeGitRepositoryGoGit(t, gitCommands...),
 			spec:         "master",
 			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
 		},
@@ -297,6 +312,11 @@ func TestRepository_ResolveTag(t *testing.T) {
 			tag:          "t",
 			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
 		},
+		"git gogits": {
+			repo:         makeGitRepositoryGoGit(t, gitCommands...),
+			tag:          "t",
+			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
+		},
 		"hg": {
 			repo:         makeHgRepositoryNative(t, hgCommands...),
 			tag:          "t",
@@ -347,6 +367,11 @@ func TestRepository_ResolveTag_error(t *testing.T) {
 		},
 		"git cmd": {
 			repo:    makeGitRepositoryCmd(t, gitCommands...),
+			tag:     "doesntexist",
+			wantErr: vcs.ErrTagNotFound,
+		},
+		"git gogits": {
+			repo:    makeGitRepositoryGoGit(t, gitCommands...),
 			tag:     "doesntexist",
 			wantErr: vcs.ErrTagNotFound,
 		},
@@ -822,6 +847,12 @@ func TestRepository_Commits(t *testing.T) {
 			wantCommits: wantGitCommits,
 			wantTotal:   2,
 		},
+		"git gogits": {
+			repo:        makeGitRepositoryGoGit(t, gitCommands...),
+			id:          "b266c7e3ca00b1a17ad0b1449825d0854225c007",
+			wantCommits: wantGitCommits,
+			wantTotal:   2,
+		},
 		"hg native": {
 			repo:        makeHgRepositoryNative(t, hgCommands...),
 			id:          "c6320cdba5ebc6933bd7c94751dcd633d6aa0759",
@@ -932,6 +963,12 @@ func TestRepository_Commits_options(t *testing.T) {
 		},
 		"git cmd": {
 			repo:        makeGitRepositoryCmd(t, gitCommands...),
+			opt:         vcs.CommitsOptions{Head: "ade564eba4cf904492fb56dcd287ac633e6e082c", N: 1, Skip: 1},
+			wantCommits: wantGitCommits,
+			wantTotal:   3,
+		},
+		"git gogits": {
+			repo:        makeGitRepositoryGoGit(t, gitCommands...),
 			opt:         vcs.CommitsOptions{Head: "ade564eba4cf904492fb56dcd287ac633e6e082c", N: 1, Skip: 1},
 			wantCommits: wantGitCommits,
 			wantTotal:   3,

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -1838,7 +1838,7 @@ func makeGitRepositoryLibGit2(t testing.TB, cmds ...string) *git.Repository {
 // returns the repository.
 func makeGitRepositoryGoGit(t testing.TB, cmds ...string) *gogit.Repository {
 	dir := initGitRepository(t, cmds...)
-	r, err := gogit.Open(filepath.Join(dir, ".git"))
+	r, err := gogit.Open(dir)
 	if err != nil {
 		t.Fatalf("gogit.Open(%q) failed: %s", dir, err)
 	}

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/tools/godoc/vfs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/git"
+	gogit "sourcegraph.com/sourcegraph/go-vcs/vcs/git/gogit"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/gitcmd"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/hg"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/hgcmd"
@@ -406,6 +407,10 @@ func TestRepository_Branches(t *testing.T) {
 			repo:         makeGitRepositoryCmd(t, gitCommands...),
 			wantBranches: []*vcs.Branch{{Name: "b0", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "b1", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "master", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}},
 		},
+		"git gogits": {
+			repo:         makeGitRepositoryGoGit(t, gitCommands...),
+			wantBranches: []*vcs.Branch{{Name: "b0", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "b1", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "master", Head: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}},
+		},
 		"hg": {
 			repo:         makeHgRepositoryNative(t, hgCommands...),
 			wantBranches: []*vcs.Branch{{Name: "b0", Head: "4edb70f7b9dd1ce8e95242525377098f477a89c3"}, {Name: "b1", Head: "843c6421bd707b885cc3849b8eb0b5b2b9298e8b"}},
@@ -641,6 +646,10 @@ func TestRepository_Tags(t *testing.T) {
 		},
 		"git cmd": {
 			repo:     makeGitRepositoryCmd(t, gitCommands...),
+			wantTags: []*vcs.Tag{{Name: "t0", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "t1", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}},
+		},
+		"git gogits": {
+			repo:     makeGitRepositoryGoGit(t, gitCommands...),
 			wantTags: []*vcs.Tag{{Name: "t0", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}, {Name: "t1", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"}},
 		},
 		"hg": {
@@ -1755,6 +1764,18 @@ func makeGitRepositoryLibGit2(t testing.TB, cmds ...string) *git.Repository {
 	r, err := git.Open(dir)
 	if err != nil {
 		t.Fatalf("git.Open(%q) failed: %s", dir, err)
+	}
+	return r
+}
+
+// makeGitRepositoryGoGit calls initGitRepository to create a new Git
+// (native-go implementation) repository and run cmds in it, and then
+// returns the repository.
+func makeGitRepositoryGoGit(t testing.TB, cmds ...string) *gogit.Repository {
+	dir := initGitRepository(t, cmds...)
+	r, err := gogit.Open(filepath.Join(dir, ".git"))
+	if err != nil {
+		t.Fatalf("gogit.Open(%q) failed: %s", dir, err)
 	}
 	return r
 }


### PR DESCRIPTION
Implementing using a forked version of gogits/git: https://github.com/shazow/go-git
## Notes & Caveats
- No locking.
- [x] TODO: Check race detection
## Benchmarks

```
BenchmarkFileSystem_GitLibGit2-4        1000       2046903 ns/op
BenchmarkFileSystem_GitCmd-4               3     397120043 ns/op
BenchmarkFileSystem_GitGoGit-4           300       4026226 ns/op
BenchmarkGetCommit_GitLibGit2-4         5000        303440 ns/op
BenchmarkGetCommit_GitCmd-4                3     468873007 ns/op
BenchmarkGetCommit_GitGoGit-4          10000        106772 ns/op
BenchmarkCommits_GitLibGit2-4           2000       1041833 ns/op
BenchmarkCommits_GitCmd-4                  3     501924754 ns/op
BenchmarkCommits_GitGoGit-4                3     455134983 ns/op
```

Lots of room for optimization in the FileSystem implementation, very naive right now. Suspicious that GetCommit_GitGoGit beats the LibGit2 implementation, the code might be doing something wrong/incomplete.
## Progress
### `TestRepository`
- [ ] TestMerger_CrossRepoMergeBase (low priority)
- [ ] TestMerger_MergeBase
- [ ] TestRepository_BlameFile
- [x] TestRepository_Branches
- [x] TestRepository_Branches_BehindAheadCounts
- [x] TestRepository_Branches_ContainsCommit
- [x] TestRepository_Branches_IncludeCommit
- [x] TestRepository_Branches_MergedInto
- [x] TestRepository_Commits
- [x] TestRepository_Commits_options
- [x] TestRepository_Commits_options_path
- [ ] TestRepository_CrossRepoDiff_git (low priority)
- [ ] TestRepository_Diff
- [ ] TestRepository_Diff_rename
- [x] TestRepository_FileLister
- [x] TestRepository_FileSystem
- [x] TestRepository_FileSystem_Symlinks
- [ ] TestRepository_FileSystem_gitSubmodules (low priority)
- [x] TestRepository_GetCommit
- [x] TestRepository_ResolveBranch
- [x] TestRepository_ResolveBranch_error
- [x] TestRepository_ResolveRevision
- [x] TestRepository_ResolveRevision_error
- [x] TestRepository_ResolveTag
- [x] TestRepository_ResolveTag_error
- [ ] TestRepository_Search (low-ish priority)
- [ ] TestRepository_Search_LongLine (low-ish priority)
- [x] TestRepository_Tags
